### PR TITLE
Add cannonical names (iaspec)

### DIFF
--- a/data/command-cards.json
+++ b/data/command-cards.json
@@ -4,1441 +4,1647 @@
     "name": "A Powerful Influence",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/a-powerful-influence.png"
+    "image": "command-cards/a-powerful-influence.png",
+    "iaspec": "apowerfulinfluence"
   },
   {
     "id": 1,
     "name": "Adrenaline",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/adrenaline.png"
+    "image": "command-cards/adrenaline.png",
+    "iaspec": "adrenaline"
   },
   {
     "id": 2,
     "name": "Advance Warning",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/advance-warning.png"
+    "image": "command-cards/advance-warning.png",
+    "iaspec": "advancewarning"
   },
   {
     "id": 3,
     "name": "Against the Odds",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/against-the-odds.png"
+    "image": "command-cards/against-the-odds.png",
+    "iaspec": "againsttheodds"
   },
   {
     "id": 4,
     "name": "Assassinate",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/assassinate.png"
+    "image": "command-cards/assassinate.png",
+    "iaspec": "assassinate"
   },
   {
     "id": 5,
     "name": "Ballistics Matrix",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/ballistics-matrix.png"
+    "image": "command-cards/ballistics-matrix.png",
+    "iaspec": "ballisticsmatrix"
   },
   {
     "id": 6,
     "name": "Battlefield Awareness",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/battlefield-awareness.png"
+    "image": "command-cards/battlefield-awareness.png",
+    "iaspec": "battlefieldawareness"
   },
   {
     "id": 7,
     "name": "Behind Enemy Lines",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/behind-enemy-lines.png"
+    "image": "command-cards/behind-enemy-lines.png",
+    "iaspec": "behindenemylines"
   },
   {
     "id": 8,
     "name": "Black Market Prices",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/black-market-prices.png"
+    "image": "command-cards/black-market-prices.png",
+    "iaspec": "blackmarketprices"
   },
   {
     "id": 9,
     "name": "Bladestorm",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/bladestorm.png"
+    "image": "command-cards/bladestorm.png",
+    "iaspec": "bladestorm"
   },
   {
     "id": 10,
     "name": "Blaze of Glory",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/blaze-of-glory.png"
+    "image": "command-cards/blaze-of-glory.png",
+    "iaspec": "blazeofglory"
   },
   {
     "id": 11,
     "name": "Blitz",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/blitz.png"
+    "image": "command-cards/blitz.png",
+    "iaspec": "blitz"
   },
   {
     "id": 12,
     "name": "Blood Feud",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/blood-feud.png"
+    "image": "command-cards/blood-feud.png",
+    "iaspec": "bloodfeud"
   },
   {
     "id": 13,
     "name": "Bodyguard",
     "cost": 1,
     "limit": 2,
-    "image": "command-cards/bodyguard.png"
+    "image": "command-cards/bodyguard.png",
+    "iaspec": "bodyguard"
   },
   {
     "id": 14,
     "name": "Brace Yourself",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/brace-yourself.png"
+    "image": "command-cards/brace-yourself.png",
+    "iaspec": "braceyourself"
   },
   {
     "id": 15,
     "name": "Brace for Impact",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/brace-for-impact.png"
+    "image": "command-cards/brace-for-impact.png",
+    "iaspec": "braceforimpact"
   },
   {
     "id": 16,
     "name": "Burst Fire",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/burst-fire.png"
+    "image": "command-cards/burst-fire.png",
+    "iaspec": "burstfire"
   },
   {
     "id": 17,
     "name": "Call the Vanguard",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/call-the-vanguard.png"
+    "image": "command-cards/call-the-vanguard.png",
+    "iaspec": "callthevanguard"
   },
   {
     "id": 18,
     "name": "Camouflage",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/camouflage.png"
+    "image": "command-cards/camouflage.png",
+    "iaspec": "camouflage"
   },
   {
     "id": 19,
     "name": "Capture The Weary",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/capture-the-weary.png"
+    "image": "command-cards/capture-the-weary.png",
+    "iaspec": "capturetheweary"
   },
   {
     "id": 20,
     "name": "Cavalry Charge",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/cavalry-charge.png"
+    "image": "command-cards/cavalry-charge.png",
+    "iaspec": "cavalrycharge"
   },
   {
     "id": 21,
     "name": "Celebration",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/celebration.png"
+    "image": "command-cards/celebration.png",
+    "iaspec": "celebration"
   },
   {
     "id": 22,
     "name": "Change of Plans",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/change-of-plans.png"
+    "image": "command-cards/change-of-plans.png",
+    "iaspec": "changeofplans"
   },
   {
     "id": 23,
     "name": "Cheat to Win",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/cheat-to-win.png"
+    "image": "command-cards/cheat-to-win.png",
+    "iaspec": "cheattowin"
   },
   {
     "id": 24,
     "name": "Close the Gap",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/close-the-gap.png"
+    "image": "command-cards/close-the-gap.png",
+    "iaspec": "closethegap"
   },
   {
     "id": 25,
     "name": "Collect Intel",
     "cost": 1,
     "limit": 2,
-    "image": "command-cards/collect-intel.png"
+    "image": "command-cards/collect-intel.png",
+    "iaspec": "collectintel"
   },
   {
     "id": 26,
     "name": "Comm Disruption",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/comm-disruption.png"
+    "image": "command-cards/comm-disruption.png",
+    "iaspec": "commdisruption"
   },
   {
     "id": 27,
     "name": "Coordinated Attack",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/coordinated-attack.png"
+    "image": "command-cards/coordinated-attack.png",
+    "iaspec": "coordinatedattack"
   },
   {
     "id": 28,
     "name": "Counter Attack",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/counter-attack.png"
+    "image": "command-cards/counter-attack.png",
+    "iaspec": "counterattack"
   },
   {
     "id": 29,
     "name": "Covering Fire",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/covering-fire.png"
+    "image": "command-cards/covering-fire.png",
+    "iaspec": "coveringfire"
   },
   {
     "id": 30,
     "name": "Cripple",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/cripple.png"
+    "image": "command-cards/cripple.png",
+    "iaspec": "cripple"
   },
   {
     "id": 31,
     "name": "Cruel Strike",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/cruel-strike.png"
+    "image": "command-cards/cruel-strike.png",
+    "iaspec": "cruelstrike"
   },
   {
     "id": 32,
     "name": "Crush",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/crush.png"
+    "image": "command-cards/crush.png",
+    "iaspec": "crush"
   },
   {
     "id": 33,
     "name": "Cut Lines",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/cut-lines.png"
+    "image": "command-cards/cut-lines.png",
+    "iaspec": "cutlines"
   },
   {
     "id": 34,
     "name": "Dangerous Bargains",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/dangerous-bargains.png"
+    "image": "command-cards/dangerous-bargains.png",
+    "iaspec": "dangerousbargains"
   },
   {
     "id": 35,
     "name": "Data Theft",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/data-theft.png"
+    "image": "command-cards/data-theft.png",
+    "iaspec": "datatheft"
   },
   {
     "id": 36,
     "name": "Deadeye",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/deadeye.png"
+    "image": "command-cards/deadeye.png",
+    "iaspec": "deadeye"
   },
   {
     "id": 37,
     "name": "Deadly Precision",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/deadly-precision.png"
+    "image": "command-cards/deadly-precision.png",
+    "iaspec": "deadlyprecision"
   },
   {
     "id": 38,
     "name": "Debts Repaid",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/debts-repaid.png"
+    "image": "command-cards/debts-repaid.png",
+    "iaspec": "debtsrepaid"
   },
   {
     "id": 39,
     "name": "Deflection",
     "cost": 1,
     "limit": 2,
-    "image": "command-cards/deflection.png"
+    "image": "command-cards/deflection.png",
+    "iaspec": "deflection"
   },
   {
     "id": 40,
     "name": "Devotion",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/devotion.png"
+    "image": "command-cards/devotion.png",
+    "iaspec": "devotion"
   },
   {
     "id": 41,
     "name": "Dirty Trick",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/dirty-trick.png"
+    "image": "command-cards/dirty-trick.png",
+    "iaspec": "dirtytrick"
   },
   {
     "id": 42,
     "name": "Disable",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/disable.png"
+    "image": "command-cards/disable.png",
+    "iaspec": "disable"
   },
   {
     "id": 43,
     "name": "Disorient",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/disorient.png"
+    "image": "command-cards/disorient.png",
+    "iaspec": "disorient"
   },
   {
     "id": 44,
     "name": "Draw",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/draw.png"
+    "image": "command-cards/draw.png",
+    "iaspec": "draw"
   },
   {
     "id": 45,
     "name": "Eerie Visage",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/eerie-visage.png"
+    "image": "command-cards/eerie-visage.png",
+    "iaspec": "eerievisage"
   },
   {
     "id": 46,
     "name": "Efficient Travel",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/efficient-travel.png"
+    "image": "command-cards/efficient-travel.png",
+    "iaspec": "efficienttravel"
   },
   {
     "id": 47,
     "name": "Element of Surprise",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/element-of-surprise.png"
+    "image": "command-cards/element-of-surprise.png",
+    "iaspec": "elementofsurprise"
   },
   {
     "id": 48,
     "name": "Emergency Aid",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/emergency-aid.png"
+    "image": "command-cards/emergency-aid.png",
+    "iaspec": "emergencyaid"
   },
   {
     "id": 49,
     "name": "Endless Reserves",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/endless-reserves.png"
+    "image": "command-cards/endless-reserves.png",
+    "iaspec": "endlessreserves"
   },
   {
     "id": 50,
     "name": "Espionage Mastery",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/espionage-mastery.png"
+    "image": "command-cards/espionage-mastery.png",
+    "iaspec": "espionagemastery"
   },
   {
     "id": 51,
     "name": "Etiquette and Protocol",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/etiquette-and-protocol.png"
+    "image": "command-cards/etiquette-and-protocol.png",
+    "iaspec": "etiquetteandprotocol"
   },
   {
     "id": 52,
     "name": "Evacuate",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/evacuate.png"
+    "image": "command-cards/evacuate.png",
+    "iaspec": "evacuate"
   },
   {
     "id": 53,
     "name": "Explosive Weaponry",
     "cost": 1,
     "limit": 2,
-    "image": "command-cards/explosive-weaponry.png"
+    "image": "command-cards/explosive-weaponry.png",
+    "iaspec": "explosiveweaponry"
   },
   {
     "id": 54,
     "name": "Expose Weakness",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/expose-weakness.png"
+    "image": "command-cards/expose-weakness.png",
+    "iaspec": "exposeweakness"
   },
   {
     "id": 55,
     "name": "Extra Protection",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/extra-protection.png"
+    "image": "command-cards/extra-protection.png",
+    "iaspec": "extraprotection"
   },
   {
     "id": 56,
     "name": "Fatal Deception",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/fatal-deception.png"
+    "image": "command-cards/fatal-deception.png",
+    "iaspec": "fataldeception"
   },
   {
     "id": 57,
     "name": "Feral Swipes",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/feral-swipes.png"
+    "image": "command-cards/feral-swipes.png",
+    "iaspec": "feralswipes"
   },
   {
     "id": 58,
     "name": "Ferocity",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/ferocity.png"
+    "image": "command-cards/ferocity.png",
+    "iaspec": "ferocity"
   },
   {
     "id": 59,
     "name": "Field Tactician",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/field-tactician.png"
+    "image": "command-cards/field-tactician.png",
+    "iaspec": "fieldtactician"
   },
   {
     "id": 60,
     "name": "Fleet Footed",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/fleet-footed.png"
+    "image": "command-cards/fleet-footed.png",
+    "iaspec": "fleetfooted"
   },
   {
     "id": 61,
     "name": "Flurry of Blades",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/flurry-of-blades.png"
+    "image": "command-cards/flurry-of-blades.png",
+    "iaspec": "flurryofblades"
   },
   {
     "id": 62,
     "name": "Focus",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/focus.png"
+    "image": "command-cards/focus.png",
+    "iaspec": "focus"
   },
   {
     "id": 63,
     "name": "Force Illusion",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/force-illusion.png"
+    "image": "command-cards/force-illusion.png",
+    "iaspec": "forceillusion"
   },
   {
     "id": 64,
     "name": "Force Lightning",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/force-lightning.png"
+    "image": "command-cards/force-lightning.png",
+    "iaspec": "forcelightning"
   },
   {
     "id": 65,
     "name": "Force Rush",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/force-rush.png"
+    "image": "command-cards/force-rush.png",
+    "iaspec": "forcerush"
   },
   {
     "id": 66,
     "name": "Force Surge",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/force-surge.png"
+    "image": "command-cards/force-surge.png",
+    "iaspec": "forcesurge"
   },
   {
     "id": 67,
     "name": "Fuel Upgrade",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/fuel-upgrade.png"
+    "image": "command-cards/fuel-upgrade.png",
+    "iaspec": "fuelupgrade"
   },
   {
     "id": 68,
     "name": "Furious Charge",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/furious-charge.png"
+    "image": "command-cards/furious-charge.png",
+    "iaspec": "furiouscharge"
   },
   {
     "id": 69,
     "name": "Glory of the Kill",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/glory-of-the-kill.png"
+    "image": "command-cards/glory-of-the-kill.png",
+    "iaspec": "gloryofthekill"
   },
   {
     "id": 70,
     "name": "Grenadier",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/grenadier.png"
+    "image": "command-cards/grenadier.png",
+    "iaspec": "grenadier"
   },
   {
     "id": 71,
     "name": "Grisly Contest",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/grisly-contest.png"
+    "image": "command-cards/grisly-contest.png",
+    "iaspec": "grislycontest"
   },
   {
     "id": 72,
     "name": "Guardian Stance",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/guardian-stance.png"
+    "image": "command-cards/guardian-stance.png",
+    "iaspec": "guardianstance"
   },
   {
     "id": 73,
     "name": "Hard to Hit",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/hard-to-hit.png"
+    "image": "command-cards/hard-to-hit.png",
+    "iaspec": "hardtohit"
   },
   {
     "id": 74,
     "name": "Harsh Environment",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/harsh-environment.png"
+    "image": "command-cards/harsh-environment.png",
+    "iaspec": "harshenvironment"
   },
   {
     "id": 75,
     "name": "Heart of Freedom",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/heart-of-freedom.png"
+    "image": "command-cards/heart-of-freedom.png",
+    "iaspec": "heartoffreedom"
   },
   {
     "id": 76,
     "name": "Heavy Armor",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/heavy-armor.png"
+    "image": "command-cards/heavy-armor.png",
+    "iaspec": "heavyarmor"
   },
   {
     "id": 77,
     "name": "Heightened Reflexes",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/heightened-reflexes.png"
+    "image": "command-cards/heightened-reflexes.png",
+    "iaspec": "heightenedreflexes"
   },
   {
     "id": 78,
     "name": "Hidden Trap",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/hidden-trap.png"
+    "image": "command-cards/hidden-trap.png",
+    "iaspec": "hiddentrap"
   },
   {
     "id": 79,
     "name": "Hide in Plain Sight",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/hide-in-plain-sight.png"
+    "image": "command-cards/hide-in-plain-sight.png",
+    "iaspec": "hideinplainsight"
   },
   {
     "id": 80,
     "name": "Hit and Run",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/hit-and-run.png"
+    "image": "command-cards/hit-and-run.png",
+    "iaspec": "hitandrun"
   },
   {
     "id": 81,
     "name": "Hold Ground",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/hold-ground.png"
+    "image": "command-cards/hold-ground.png",
+    "iaspec": "holdground"
   },
   {
     "id": 82,
     "name": "Hunt Them Down",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/hunt-them-down.png"
+    "image": "command-cards/hunt-them-down.png",
+    "iaspec": "huntthemdown"
   },
   {
     "id": 83,
     "name": "Hunter Protocol",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/hunter-protocol.png"
+    "image": "command-cards/hunter-protocol.png",
+    "iaspec": "hunterprotocol"
   },
   {
     "id": 84,
     "name": "I Can Feel It",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/i-can-feel-it.png"
+    "image": "command-cards/i-can-feel-it.png",
+    "iaspec": "icanfeelit"
   },
   {
     "id": 85,
     "name": "I Must Go Alone",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/i-must-go-alone.png"
+    "image": "command-cards/i-must-go-alone.png",
+    "iaspec": "imustgoalone"
   },
   {
     "id": 86,
     "name": "I make my own Luck",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/i-make-my-own-luck.png"
+    "image": "command-cards/i-make-my-own-luck.png",
+    "iaspec": "imakemyownluck"
   },
   {
     "id": 87,
     "name": "Improvised Weapons",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/improvised-weapons.png"
+    "image": "command-cards/improvised-weapons.png",
+    "iaspec": "improvisedweapons"
   },
   {
     "id": 88,
     "name": "In the Shadows",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/in-the-shadows.png"
+    "image": "command-cards/in-the-shadows.png",
+    "iaspec": "intheshadows"
   },
   {
     "id": 89,
     "name": "Inspiring Speech",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/inspiring-speech.png"
+    "image": "command-cards/inspiring-speech.png",
+    "iaspec": "inspiringspeech"
   },
   {
     "id": 90,
     "name": "Intelligence Leak",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/intelligence-leak.png"
+    "image": "command-cards/intelligence-leak.png",
+    "iaspec": "intelligenceleak"
   },
   {
     "id": 91,
     "name": "Jump Jets",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/jump-jets.png"
+    "image": "command-cards/jump-jets.png",
+    "iaspec": "jumpjets"
   },
   {
     "id": 92,
     "name": "Jundland Terror",
     "cost": 2,
     "limit": 2,
-    "image": "command-cards/jundland-terror.png"
+    "image": "command-cards/jundland-terror.png",
+    "iaspec": "jundlandterror"
   },
   {
     "id": 93,
     "name": "Knowledge and Defense",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/knowledge-and-defense.png"
+    "image": "command-cards/knowledge-and-defense.png",
+    "iaspec": "knowledgeanddefense"
   },
   {
     "id": 94,
     "name": "Lock On",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/lock-on.png"
+    "image": "command-cards/lock-on.png",
+    "iaspec": "lockon"
   },
   {
     "id": 95,
     "name": "Lord of the Sith",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/lord-of-the-sith.png"
+    "image": "command-cards/lord-of-the-sith.png",
+    "iaspec": "lordofthesith"
   },
   {
     "id": 96,
     "name": "Lure of the Dark Side",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/lure-of-the-dark-side.png"
+    "image": "command-cards/lure-of-the-dark-side.png",
+    "iaspec": "lureofthedarkside"
   },
   {
     "id": 97,
     "name": "Mandalorian Tactics",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/mandalorian-tactics.png"
+    "image": "command-cards/mandalorian-tactics.png",
+    "iaspec": "mandaloriantactics"
   },
   {
     "id": 98,
     "name": "Marksman",
     "cost": 1,
     "limit": 2,
-    "image": "command-cards/marksman.png"
+    "image": "command-cards/marksman.png",
+    "iaspec": "marksman"
   },
   {
     "id": 99,
     "name": "Master Operative",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/master-operative.png"
+    "image": "command-cards/master-operative.png",
+    "iaspec": "masteroperative"
   },
   {
     "id": 100,
     "name": "Maximum Firepower",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/maximum-firepower.png"
+    "image": "command-cards/maximum-firepower.png",
+    "iaspec": "maximumfirepower"
   },
   {
     "id": 101,
     "name": "Meditation",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/meditation.png"
+    "image": "command-cards/meditation.png",
+    "iaspec": "meditation"
   },
   {
     "id": 102,
     "name": "Merciless",
     "cost": 1,
     "limit": 2,
-    "image": "command-cards/merciless.png"
+    "image": "command-cards/merciless.png",
+    "iaspec": "merciless"
   },
   {
     "id": 103,
     "name": "Miracle Worker",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/miracle-worker.png"
+    "image": "command-cards/miracle-worker.png",
+    "iaspec": "miracleworker"
   },
   {
     "id": 104,
     "name": "Mitigate",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/mitigate.png"
+    "image": "command-cards/mitigate.png",
+    "iaspec": "mitigate"
   },
   {
     "id": 105,
     "name": "Navigation Upgrade",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/navigation-upgrade.png"
+    "image": "command-cards/navigation-upgrade.png",
+    "iaspec": "navigationupgrade"
   },
   {
     "id": 106,
     "name": "Negation",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/negation.png"
+    "image": "command-cards/negation.png",
+    "iaspec": "negation"
   },
   {
     "id": 107,
     "name": "New Orders",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/new-orders.png"
+    "image": "command-cards/new-orders.png",
+    "iaspec": "neworders"
   },
   {
     "id": 108,
     "name": "Of No Importance",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/of-no-importance.png"
+    "image": "command-cards/of-no-importance.png",
+    "iaspec": "ofnoimportance"
   },
   {
     "id": 109,
     "name": "On a Mission",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/on-a-mission.png"
+    "image": "command-cards/on-a-mission.png",
+    "iaspec": "onamission"
   },
   {
     "id": 110,
     "name": "On the Lam",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/on-the-lam.png"
+    "image": "command-cards/on-the-lam.png",
+    "iaspec": "onthelam"
   },
   {
     "id": 111,
     "name": "Opportunistic",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/opportunistic.png"
+    "image": "command-cards/opportunistic.png",
+    "iaspec": "opportunistic"
   },
   {
     "id": 112,
     "name": "Optimal Bombardment",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/optimal-bombardment.png"
+    "image": "command-cards/optimal-bombardment.png",
+    "iaspec": "optimalbombardment"
   },
   {
     "id": 113,
     "name": "Overcharged Weapons",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/overcharged-weapons.png"
+    "image": "command-cards/overcharged-weapons.png",
+    "iaspec": "overchargedweapons"
   },
   {
     "id": 114,
     "name": "Overdrive",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/overdrive.png"
+    "image": "command-cards/overdrive.png",
+    "iaspec": "overdrive"
   },
   {
     "id": 115,
     "name": "Overrun",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/overrun.png"
+    "image": "command-cards/overrun.png",
+    "iaspec": "overrun"
   },
   {
     "id": 116,
     "name": "Parry",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/parry.png"
+    "image": "command-cards/parry.png",
+    "iaspec": "parry"
   },
   {
     "id": 117,
     "name": "Parting Blow",
     "cost": 2,
     "limit": 2,
-    "image": "command-cards/parting-blow.png"
+    "image": "command-cards/parting-blow.png",
+    "iaspec": "partingblow"
   },
   {
     "id": 118,
     "name": "Payback",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/payback.png"
+    "image": "command-cards/payback.png",
+    "iaspec": "payback"
   },
   {
     "id": 119,
     "name": "Pickpocket",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/pickpocket.png"
+    "image": "command-cards/pickpocket.png",
+    "iaspec": "pickpocket"
   },
   {
     "id": 120,
     "name": "Positioning Advantage",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/positioning-advantage.png"
+    "image": "command-cards/positioning-advantage.png",
+    "iaspec": "positioningadvantage"
   },
   {
     "id": 121,
     "name": "Primary Target",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/primary-target.png"
+    "image": "command-cards/primary-target.png",
+    "iaspec": "primarytarget"
   },
   {
     "id": 122,
     "name": "Provoke",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/provoke.png"
+    "image": "command-cards/provoke.png",
+    "iaspec": "provoke"
   },
   {
     "id": 123,
     "name": "Rally The Troops",
     "cost": 3,
     "limit": 1,
-    "image": "command-cards/rally-the-troops.png"
+    "image": "command-cards/rally-the-troops.png",
+    "iaspec": "rallythetroops"
   },
   {
     "id": 124,
     "name": "Rank and File",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/rank-and-file.png"
+    "image": "command-cards/rank-and-file.png",
+    "iaspec": "rankandfile"
   },
   {
     "id": 125,
     "name": "Reinforcements",
     "cost": 2,
     "limit": 2,
-    "image": "command-cards/reinforcements.png"
+    "image": "command-cards/reinforcements.png",
+    "iaspec": "reinforcements"
   },
   {
     "id": 126,
     "name": "Repair",
     "cost": 2,
     "limit": 2,
-    "image": "command-cards/repair.png"
+    "image": "command-cards/repair.png",
+    "iaspec": "repair"
   },
   {
     "id": 127,
     "name": "Reposition",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/reposition.png"
+    "image": "command-cards/reposition.png",
+    "iaspec": "reposition"
   },
   {
     "id": 128,
     "name": "Roar",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/roar.png"
+    "image": "command-cards/roar.png",
+    "iaspec": "roar"
   },
   {
     "id": 129,
     "name": "Run for Cover",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/run-for-cover.png"
+    "image": "command-cards/run-for-cover.png",
+    "iaspec": "runforcover"
   },
   {
     "id": 130,
     "name": "Self Defense",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/self-defense.png"
+    "image": "command-cards/self-defense.png",
+    "iaspec": "selfdefense"
   },
   {
     "id": 131,
     "name": "Set For Stun",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/set-for-stun.png"
+    "image": "command-cards/set-for-stun.png",
+    "iaspec": "setforstun"
   },
   {
     "id": 132,
     "name": "Set a Trap",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/set-a-trap.png"
+    "image": "command-cards/set-a-trap.png",
+    "iaspec": "setatrap"
   },
   {
     "id": 133,
     "name": "Shared Experience",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/shared-experience.png"
+    "image": "command-cards/shared-experience.png",
+    "iaspec": "sharedexperience"
   },
   {
     "id": 134,
     "name": "Shoot the Messenger",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/shoot-the-messenger.png"
+    "image": "command-cards/shoot-the-messenger.png",
+    "iaspec": "shootthemessenger"
   },
   {
     "id": 135,
     "name": "Single Purpose",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/single-purpose.png"
+    "image": "command-cards/single-purpose.png",
+    "iaspec": "singlepurpose"
   },
   {
     "id": 136,
     "name": "Size Advantage",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/size-advantage.png"
+    "image": "command-cards/size-advantage.png",
+    "iaspec": "sizeadvantage"
   },
   {
     "id": 137,
     "name": "Slippery Target",
     "cost": 2,
     "limit": 2,
-    "image": "command-cards/slippery-target.png"
+    "image": "command-cards/slippery-target.png",
+    "iaspec": "slipperytarget"
   },
   {
     "id": 138,
     "name": "Smuggled Supplies",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/smuggled-supplies.png"
+    "image": "command-cards/smuggled-supplies.png",
+    "iaspec": "smuggledsupplies"
   },
   {
     "id": 139,
     "name": "Smugglers Tricks",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/smugglers-tricks.png"
+    "image": "command-cards/smugglers-tricks.png",
+    "iaspec": "smugglerstricks"
   },
   {
     "id": 140,
     "name": "Squad Swarm",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/squad-swarm.png"
+    "image": "command-cards/squad-swarm.png",
+    "iaspec": "squadswarm"
   },
   {
     "id": 141,
     "name": "Stall for Time",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/stall-for-time.png"
+    "image": "command-cards/stall-for-time.png",
+    "iaspec": "stallfortime"
   },
   {
     "id": 142,
     "name": "Stay Down",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/stay-down.png"
+    "image": "command-cards/stay-down.png",
+    "iaspec": "staydown"
   },
   {
     "id": 143,
     "name": "Stealth Tactics",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/stealth-tactics.png"
+    "image": "command-cards/stealth-tactics.png",
+    "iaspec": "stealthtactics"
   },
   {
     "id": 144,
     "name": "Stimulants",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/stimulants.png"
+    "image": "command-cards/stimulants.png",
+    "iaspec": "stimulants"
   },
   {
     "id": 145,
     "name": "Strategic Shift",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/strategic-shift.png"
+    "image": "command-cards/strategic-shift.png",
+    "iaspec": "strategicshift"
   },
   {
     "id": 146,
     "name": "Strength in Numbers",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/strength-in-numbers.png"
+    "image": "command-cards/strength-in-numbers.png",
+    "iaspec": "strengthinnumbers"
   },
   {
     "id": 147,
     "name": "Stroke of Brilliance",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/stroke-of-brilliance.png"
+    "image": "command-cards/stroke-of-brilliance.png",
+    "iaspec": "strokeofbrilliance"
   },
   {
     "id": 148,
     "name": "Survival Instincts",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/survival-instincts.png"
+    "image": "command-cards/survival-instincts.png",
+    "iaspec": "survivalinstincts"
   },
   {
     "id": 149,
     "name": "Take Position",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/take-position.png"
+    "image": "command-cards/take-position.png",
+    "iaspec": "takeposition"
   },
   {
     "id": 150,
     "name": "Targeting Network",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/targeting-network.png"
+    "image": "command-cards/targeting-network.png",
+    "iaspec": "targetingnetwork"
   },
   {
     "id": 151,
     "name": "Terminal Network",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/terminal-network.png"
+    "image": "command-cards/terminal-network.png",
+    "iaspec": "terminalnetwork"
   },
   {
     "id": 152,
     "name": "Terminal Protocol",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/terminal-protocol.png"
+    "image": "command-cards/terminal-protocol.png",
+    "iaspec": "terminalprotocol"
   },
   {
     "id": 153,
     "name": "There is Another",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/there-is-another.png"
+    "image": "command-cards/there-is-another.png",
+    "iaspec": "thereisanother"
   },
   {
     "id": 154,
     "name": "Tools for the Job",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/tools-for-the-job.png"
+    "image": "command-cards/tools-for-the-job.png",
+    "iaspec": "toolsforthejob"
   },
   {
     "id": 155,
     "name": "Tough Luck",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/tough-luck.png"
+    "image": "command-cards/tough-luck.png",
+    "iaspec": "toughluck"
   },
   {
     "id": 156,
     "name": "Toxic Dart",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/toxic-dart.png"
+    "image": "command-cards/toxic-dart.png",
+    "iaspec": "toxicdart"
   },
   {
     "id": 157,
     "name": "Trandoshan Terror",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/trandoshan-terror.png"
+    "image": "command-cards/trandoshan-terror.png",
+    "iaspec": "trandoshanterror"
   },
   {
     "id": 158,
     "name": "Triangulate",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/triangulate.png"
+    "image": "command-cards/triangulate.png",
+    "iaspec": "triangulate"
   },
   {
     "id": 159,
     "name": "Utinni",
     "cost": 1,
     "limit": 1,
-    "image": "command-cards/utinni.png"
+    "image": "command-cards/utinni.png",
+    "iaspec": "utinni"
   },
   {
     "id": 160,
     "name": "Vanish",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/vanish.png"
+    "image": "command-cards/vanish.png",
+    "iaspec": "vanish"
   },
   {
     "id": 161,
     "name": "Wild Attack",
     "cost": 0,
     "limit": 1,
-    "image": "command-cards/wild-attack.png"
+    "image": "command-cards/wild-attack.png",
+    "iaspec": "wildattack"
   },
   {
     "id": 162,
     "name": "Wild Fury",
     "cost": 2,
     "limit": 1,
-    "image": "command-cards/wild-fury.png"
+    "image": "command-cards/wild-fury.png",
+    "iaspec": "wildfury"
   },
   {
     "id": 163,
     "name": "Wookiee Rage",
     "cost": 2,
     "limit": 2,
-    "image": "command-cards/wookiee-rage.png"
+    "image": "command-cards/wookiee-rage.png",
+    "iaspec": "wookieerage"
   },
   {
     "name": "Arcing Shot",
     "cost": 1,
     "limit": 1,
     "id": 164,
-    "image": "command-cards/arcing-shot.png"
+    "image": "command-cards/arcing-shot.png",
+    "iaspec": "arcingshot"
   },
   {
     "name": "Armed Escort",
     "cost": 1,
     "limit": 1,
     "id": 165,
-    "image": "command-cards/armed-escort.png"
+    "image": "command-cards/armed-escort.png",
+    "iaspec": "armedescort"
   },
   {
     "name": "Balancing Force",
     "cost": 2,
     "limit": 1,
     "id": 174,
-    "image": "command-cards/balancing-force.png"
+    "image": "command-cards/balancing-force.png",
+    "iaspec": "balancingforce"
   },
   {
     "name": "Battle Scars",
     "cost": 0,
     "limit": 1,
     "id": 166,
-    "image": "command-cards/battle-scars.png"
+    "image": "command-cards/battle-scars.png",
+    "iaspec": "battlescars"
   },
   {
     "name": "Chaotic Force",
     "cost": 2,
     "limit": 1,
     "id": 184,
-    "image": "command-cards/chaotic-force.png"
+    "image": "command-cards/chaotic-force.png",
+    "iaspec": "chaoticforce"
   },
   {
     "name": "Collateral Damage",
     "cost": 1,
     "limit": 1,
     "id": 167,
-    "image": "command-cards/collateral-damage.png"
+    "image": "command-cards/collateral-damage.png",
+    "iaspec": "collateraldamage"
   },
   {
     "name": "Concentrated Fire",
     "cost": 1,
     "limit": 1,
     "id": 168,
-    "image": "command-cards/concentrated-fire.png"
+    "image": "command-cards/concentrated-fire.png",
+    "iaspec": "concentratedfire"
   },
   {
     "name": "Corrupting Force",
     "cost": 2,
     "limit": 1,
     "id": 179,
-    "image": "command-cards/corrupting-force.png"
+    "image": "command-cards/corrupting-force.png",
+    "iaspec": "corruptingforce"
   },
   {
     "name": "Dark Energy",
     "cost": 1,
     "limit": 1,
     "id": 180,
-    "image": "command-cards/dark-energy.png"
+    "image": "command-cards/dark-energy.png",
+    "iaspec": "darkenergy"
   },
   {
     "name": "Deathblow",
     "cost": 1,
     "limit": 1,
     "id": 185,
-    "image": "command-cards/deathblow.png"
+    "image": "command-cards/deathblow.png",
+    "iaspec": "deathblow"
   },
   {
     "name": "Droid Mastery",
     "cost": 0,
     "limit": 1,
     "id": 169,
-    "image": "command-cards/droid-mastery.png"
+    "image": "command-cards/droid-mastery.png",
+    "iaspec": "droidmastery"
   },
   {
     "name": "Face to Face",
     "cost": 1,
     "limit": 1,
     "id": 186,
-    "image": "command-cards/face-to-face.png"
+    "image": "command-cards/face-to-face.png",
+    "iaspec": "facetoface"
   },
   {
     "name": "Field Supply",
     "cost": 1,
     "limit": 1,
     "id": 170,
-    "image": "command-cards/field-supply.png"
+    "image": "command-cards/field-supply.png",
+    "iaspec": "fieldsupply"
   },
   {
     "name": "Fool Me Once",
     "cost": 0,
     "limit": 1,
     "id": 175,
-    "image": "command-cards/fool-me-once.png"
+    "image": "command-cards/fool-me-once.png",
+    "iaspec": "foolmeonce"
   },
   {
     "name": "Force Jump",
     "cost": 1,
     "limit": 1,
     "id": 176,
-    "image": "command-cards/force-jump.png"
+    "image": "command-cards/force-jump.png",
+    "iaspec": "forcejump"
   },
   {
     "name": "Force Push",
     "cost": 1,
     "limit": 1,
     "id": 177,
-    "image": "command-cards/force-push.png"
+    "image": "command-cards/force-push.png",
+    "iaspec": "forcepush"
   },
   {
     "name": "Forward March",
     "cost": 1,
     "limit": 1,
     "id": 171,
-    "image": "command-cards/forward-march.png"
+    "image": "command-cards/forward-march.png",
+    "iaspec": "forwardmarch"
   },
   {
     "name": "Heavy Ordnance",
     "cost": 0,
     "limit": 1,
     "id": 172,
-    "image": "command-cards/heavy-ordnance.png"
+    "image": "command-cards/heavy-ordnance.png",
+    "iaspec": "heavyordnance"
   },
   {
     "name": "Looking for a Fight",
     "cost": 0,
     "limit": 1,
     "id": 187,
-    "image": "command-cards/looking-for-a-fight.png"
+    "image": "command-cards/looking-for-a-fight.png",
+    "iaspec": "lookingforafight"
   },
   {
     "name": "Officer's Training",
     "cost": 0,
     "limit": 1,
     "id": 181,
-    "image": "command-cards/officers-training.png"
+    "image": "command-cards/officers-training.png",
+    "iaspec": "officerstraining"
   },
   {
     "name": "Prepared for Battle",
     "cost": 2,
     "limit": 1,
     "id": 182,
-    "image": "command-cards/prepared-for-battle.png"
+    "image": "command-cards/prepared-for-battle.png",
+    "iaspec": "preparedforbattle"
   },
   {
     "name": "Ready Weapons",
     "cost": 0,
     "limit": 1,
     "id": 173,
-    "image": "command-cards/ready-weapons.png"
+    "image": "command-cards/ready-weapons.png",
+    "iaspec": "readyweapons"
   },
   {
     "name": "Right Back At Ya",
     "cost": 1,
     "limit": 1,
     "id": 178,
-    "image": "command-cards/right-back-at-ya.png"
+    "image": "command-cards/right-back-at-ya.png",
+    "iaspec": "rightbackatya"
   },
   {
     "name": "Unlimited Power",
     "cost": 2,
     "limit": 1,
     "id": 183,
-    "image": "command-cards/unlimited-power.png"
+    "image": "command-cards/unlimited-power.png",
+    "iaspec": "unlimitedpower"
   },
   {
     "name": "Wreak Vengeance",
     "cost": 1,
     "limit": 1,
     "id": 188,
-    "image": "command-cards/wreak-vengeance.png"
+    "image": "command-cards/wreak-vengeance.png",
+    "iaspec": "wreakvengeance"
   },
   {
     "name": "One in a Million",
     "cost": 2,
     "limit": 1,
     "id": 189,
-    "image": "command-cards/one-in-a-million.png"
+    "image": "command-cards/one-in-a-million.png",
+    "iaspec": "oneinamillion"
   },
   {
     "name": "Planning",
     "cost": 0,
     "limit": 1,
     "id": 190,
-    "image": "command-cards/planning.png"
+    "image": "command-cards/planning.png",
+    "iaspec": "planning"
   },
   {
     "name": "Price on Their Heads",
     "cost": 1,
     "limit": 1,
     "id": 191,
-    "image": "command-cards/price-on-their-heads.png"
+    "image": "command-cards/price-on-their-heads.png",
+    "iaspec": "priceontheirheads"
   },
   {
     "name": "Pummel",
     "cost": 1,
     "limit": 2,
     "id": 192,
-    "image": "command-cards/pummel.png"
+    "image": "command-cards/pummel.png",
+    "iaspec": "pummel"
   },
   {
     "name": "Rally",
     "cost": 0,
     "limit": 1,
     "id": 193,
-    "image": "command-cards/rally.png"
+    "image": "command-cards/rally.png",
+    "iaspec": "rally"
   },
   {
     "name": "Recovery",
     "cost": 0,
     "limit": 1,
     "id": 194,
-    "image": "command-cards/recovery.png"
+    "image": "command-cards/recovery.png",
+    "iaspec": "recovery"
   },
   {
     "name": "Regroup",
     "cost": 1,
     "limit": 2,
     "id": 195,
-    "image": "command-cards/regroup.png"
+    "image": "command-cards/regroup.png",
+    "iaspec": "regroup"
   },
   {
     "name": "Sarlacc Sweep",
     "cost": 2,
     "limit": 1,
     "id": 196,
-    "image": "command-cards/sarlacc-sweep.png"
+    "image": "command-cards/sarlacc-sweep.png",
+    "iaspec": "sarlaccsweep"
   },
   {
     "name": "Shadow Ops",
     "cost": 3,
     "limit": 1,
     "id": 197,
-    "image": "command-cards/shadow-ops.png"
+    "image": "command-cards/shadow-ops.png",
+    "iaspec": "shadowops"
   },
   {
     "name": "Sit Tight",
     "cost": 0,
     "limit": 1,
     "id": 198,
-    "image": "command-cards/sit-tight.png"
+    "image": "command-cards/sit-tight.png",
+    "iaspec": "sittight"
   },
   {
     "name": "Son of Skywalker",
     "cost": 3,
     "limit": 1,
     "id": 199,
-    "image": "command-cards/son-of-skywalker.png"
+    "image": "command-cards/son-of-skywalker.png",
+    "iaspec": "sonofskywalker"
   },
   {
     "name": "Take Cover",
     "cost": 0,
     "limit": 1,
     "id": 200,
-    "image": "command-cards/take-cover.png"
+    "image": "command-cards/take-cover.png",
+    "iaspec": "takecover"
   },
   {
     "name": "Take Initiative",
     "cost": 0,
     "limit": 1,
     "id": 201,
-    "image": "command-cards/take-initiative.png"
+    "image": "command-cards/take-initiative.png",
+    "iaspec": "takeinitiative"
   },
   {
     "name": "Take it Down",
     "cost": 3,
     "limit": 1,
     "id": 202,
-    "image": "command-cards/take-it-down.png"
+    "image": "command-cards/take-it-down.png",
+    "iaspec": "takeitdown"
   },
   {
     "name": "Telekinetic Throw",
     "cost": 1,
     "limit": 1,
     "id": 203,
-    "image": "command-cards/telekinetic-throw.png"
+    "image": "command-cards/telekinetic-throw.png",
+    "iaspec": "telekineticthrow"
   },
   {
     "name": "To the Limit",
     "cost": 0,
     "limit": 1,
     "id": 204,
-    "image": "command-cards/to-the-limit.png"
+    "image": "command-cards/to-the-limit.png",
+    "iaspec": "tothelimit"
   },
   {
     "name": "Urgency",
     "cost": 0,
     "limit": 1,
     "id": 205,
-    "image": "command-cards/urgency.png"
+    "image": "command-cards/urgency.png",
+    "iaspec": "urgency"
   }
 ]

--- a/data/companion-cards.json
+++ b/data/companion-cards.json
@@ -5,7 +5,8 @@
     "image": "companion-cards/cam-droid.png",
     "traits": [
       "Droid"
-    ]
+    ],
+    "iaspec": "camdroid"
   },
   {
     "id": 1,
@@ -13,7 +14,8 @@
     "image": "companion-cards/junk-droid.png",
     "traits": [
       "Droid"
-    ]
+    ],
+    "iaspec": "junkdroid"
   },
   {
     "id": 2,
@@ -21,7 +23,8 @@
     "image": "companion-cards/r5-astromech.png",
     "traits": [
       "Droid"
-    ]
+    ],
+    "iaspec": "r5astromech"
   },
   {
     "id": 3,
@@ -29,7 +32,8 @@
     "image": "companion-cards/pit-droid.png",
     "traits": [
       "Droid"
-    ]
+    ],
+    "iaspec": "pitdroid"
   },
   {
     "id": 4,
@@ -37,7 +41,8 @@
     "image": "companion-cards/salacious-b-crumb.png",
     "traits": [
       "Brawler"
-    ]
+    ],
+    "iaspec": "salaciousbcrumb"
   },
   {
     "id": 5,
@@ -45,7 +50,8 @@
     "image": "companion-cards/88-z.png",
     "traits": [
       "Droid"
-    ]
+    ],
+    "iaspec": "88z"
   },
   {
     "id": 6,
@@ -53,6 +59,7 @@
     "image": "companion-cards/j4x-7.png",
     "traits": [
       "Droid"
-    ]
+    ],
+    "iaspec": "j4x7"
   }
 ]

--- a/data/deployment-cards.json
+++ b/data/deployment-cards.json
@@ -16,7 +16,8 @@
     "deployment_cost": 4,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/0-0-0-specialized-in-pain.png"
+    "image": "deployment-cards/0-0-0-specialized-in-pain.png",
+    "iaspec": "000"
   },
   {
     "id": 1,
@@ -36,7 +37,8 @@
     "deployment_cost": 14,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/at-st-elite.png"
+    "image": "deployment-cards/at-st-elite.png",
+    "iaspec": "eliteatst"
   },
   {
     "id": 2,
@@ -54,7 +56,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/advanced-com-systems-skirmish.png"
+    "image": "deployment-cards/advanced-com-systems-skirmish.png",
+    "iaspec": "advancedcomsystems"
   },
   {
     "id": 3,
@@ -73,7 +76,8 @@
     "deployment_cost": 6,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/agent-blaise-isb-interrogator-campaign.png"
+    "image": "deployment-cards/agent-blaise-isb-interrogator-campaign.png",
+    "iaspec": "agentblaisecampaign"
   },
   {
     "id": 4,
@@ -92,7 +96,8 @@
     "deployment_cost": 6,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/agent-blaise-isb-interrogator-skirmish.png"
+    "image": "deployment-cards/agent-blaise-isb-interrogator-skirmish.png",
+    "iaspec": "agentblaiseskirmish"
   },
   {
     "id": 5,
@@ -112,7 +117,8 @@
     "deployment_cost": 9,
     "reinforce_cost": 3,
     "deployment_group": 3,
-    "image": "deployment-cards/alliance-ranger.png"
+    "image": "deployment-cards/alliance-ranger.png",
+    "iaspec": "allianceranger"
   },
   {
     "id": 6,
@@ -132,7 +138,8 @@
     "deployment_cost": 12,
     "reinforce_cost": 4,
     "deployment_group": 3,
-    "image": "deployment-cards/alliance-ranger-elite.png"
+    "image": "deployment-cards/alliance-ranger-elite.png",
+    "iaspec": "eliteallianceranger"
   },
   {
     "id": 7,
@@ -151,7 +158,8 @@
     "deployment_cost": 2,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/alliance-smuggler.png"
+    "image": "deployment-cards/alliance-smuggler.png",
+    "iaspec": "alliancesmuggler"
   },
   {
     "id": 8,
@@ -170,7 +178,8 @@
     "deployment_cost": 4,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/alliance-smuggler-elite.png"
+    "image": "deployment-cards/alliance-smuggler-elite.png",
+    "iaspec": "elitealliancesmuggler"
   },
   {
     "id": 9,
@@ -191,7 +200,8 @@
     "deployment_cost": 6,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/bt-1-destructive-assassin.png"
+    "image": "deployment-cards/bt-1-destructive-assassin.png",
+    "iaspec": "bt1"
   },
   {
     "id": 10,
@@ -209,7 +219,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/balance-of-the-force-skirmish.png"
+    "image": "deployment-cards/balance-of-the-force-skirmish.png",
+    "iaspec": "balanceoftheforce"
   },
   {
     "id": 11,
@@ -229,7 +240,8 @@
     "deployment_cost": 9,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/bantha-rider-elite.png"
+    "image": "deployment-cards/bantha-rider-elite.png",
+    "iaspec": "elitebantharider"
   },
   {
     "id": 12,
@@ -247,7 +259,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/beast-tamer-skirmish.png"
+    "image": "deployment-cards/beast-tamer-skirmish.png",
+    "iaspec": "beasttamer"
   },
   {
     "id": 13,
@@ -266,7 +279,8 @@
     "deployment_cost": 9,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/biv-bodhrik-skirmish.png"
+    "image": "deployment-cards/biv-bodhrik-skirmish.png",
+    "iaspec": "bivbodhrik"
   },
   {
     "id": 14,
@@ -284,7 +298,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/black-market-skirmish.png"
+    "image": "deployment-cards/black-market-skirmish.png",
+    "iaspec": "blackmarket"
   },
   {
     "id": 15,
@@ -303,7 +318,8 @@
     "deployment_cost": 13,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/boba-fett-infamous-bounty-hunter.png"
+    "image": "deployment-cards/boba-fett-infamous-bounty-hunter.png",
+    "iaspec": "bobafett"
   },
   {
     "id": 16,
@@ -323,7 +339,8 @@
     "deployment_cost": 8,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/bossk-born-hunter.png"
+    "image": "deployment-cards/bossk-born-hunter.png",
+    "iaspec": "bosskmercenary"
   },
   {
     "id": 17,
@@ -343,7 +360,8 @@
     "deployment_cost": 8,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/bossk-born-hunter.png"
+    "image": "deployment-cards/bossk-born-hunter.png",
+    "iaspec": "bosskrebel"
   },
   {
     "id": 18,
@@ -362,7 +380,8 @@
     "deployment_cost": 2,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/c-3po-human-cyborg-relations.png"
+    "image": "deployment-cards/c-3po-human-cyborg-relations.png",
+    "iaspec": "c3po"
   },
   {
     "id": 19,
@@ -381,7 +400,8 @@
     "deployment_cost": 3,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/c1-10p-chopper.png"
+    "image": "deployment-cards/c1-10p-chopper.png",
+    "iaspec": "c110p"
   },
   {
     "id": 20,
@@ -402,7 +422,8 @@
     "deployment_cost": 7,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/captain-terro-wasteland-enforcer.png"
+    "image": "deployment-cards/captain-terro-wasteland-enforcer.png",
+    "iaspec": "captainterro"
   },
   {
     "id": 21,
@@ -420,7 +441,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/channel-the-force-skirmish.png"
+    "image": "deployment-cards/channel-the-force-skirmish.png",
+    "iaspec": "channeltheforce"
   },
   {
     "id": 22,
@@ -441,7 +463,8 @@
     "deployment_cost": 15,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/chewbacca-loyal-wookiee.png"
+    "image": "deployment-cards/chewbacca-loyal-wookiee.png",
+    "iaspec": "chewbacca"
   },
   {
     "id": 23,
@@ -459,7 +482,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/combat-suit-skirmish.png"
+    "image": "deployment-cards/combat-suit-skirmish.png",
+    "iaspec": "combatsuit"
   },
   {
     "id": 24,
@@ -477,7 +501,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/cross-training-elite-skirmish.png"
+    "image": "deployment-cards/cross-training-elite-skirmish.png",
+    "iaspec": "elitecrosstraining"
   },
   {
     "id": 25,
@@ -498,7 +523,8 @@
     "deployment_cost": 18,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/darth-vader-lord-of-the-sith.png"
+    "image": "deployment-cards/darth-vader-lord-of-the-sith.png",
+    "iaspec": "darthvader"
   },
   {
     "id": 26,
@@ -517,7 +543,8 @@
     "deployment_cost": 6,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/davith-elso-skirmish.png"
+    "image": "deployment-cards/davith-elso-skirmish.png",
+    "iaspec": "davithelso"
   },
   {
     "id": 27,
@@ -536,7 +563,8 @@
     "deployment_cost": 7,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/dengar-ruthless-killer.png"
+    "image": "deployment-cards/dengar-ruthless-killer.png",
+    "iaspec": "dengar"
   },
   {
     "id": 28,
@@ -554,7 +582,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/devious-scheme-skirmish.png"
+    "image": "deployment-cards/devious-scheme-skirmish.png",
+    "iaspec": "deviousscheme"
   },
   {
     "id": 29,
@@ -574,7 +603,8 @@
     "deployment_cost": 5,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/dewback-rider-elite.png"
+    "image": "deployment-cards/dewback-rider-elite.png",
+    "iaspec": "elitedewbackrider"
   },
   {
     "id": 30,
@@ -593,7 +623,8 @@
     "deployment_cost": 7,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/diala-passil-skirmish.png"
+    "image": "deployment-cards/diala-passil-skirmish.png",
+    "iaspec": "dialapassil"
   },
   {
     "id": 31,
@@ -613,7 +644,8 @@
     "deployment_cost": 6,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/e-web-engineer.png"
+    "image": "deployment-cards/e-web-engineer.png",
+    "iaspec": "ewebengineer"
   },
   {
     "id": 32,
@@ -633,7 +665,8 @@
     "deployment_cost": 8,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/e-web-engineer-elite.png"
+    "image": "deployment-cards/e-web-engineer-elite.png",
+    "iaspec": "eliteewebengineer"
   },
   {
     "id": 33,
@@ -652,7 +685,8 @@
     "deployment_cost": 6,
     "reinforce_cost": 3,
     "deployment_group": 2,
-    "image": "deployment-cards/echo-base-trooper.png"
+    "image": "deployment-cards/echo-base-trooper.png",
+    "iaspec": "echobasetrooper"
   },
   {
     "id": 34,
@@ -671,7 +705,8 @@
     "deployment_cost": 8,
     "reinforce_cost": 4,
     "deployment_group": 2,
-    "image": "deployment-cards/echo-base-trooper-elite.png"
+    "image": "deployment-cards/echo-base-trooper-elite.png",
+    "iaspec": "eliteechobasetrooper"
   },
   {
     "id": 35,
@@ -689,7 +724,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/explosive-armaments-skirmish.png"
+    "image": "deployment-cards/explosive-armaments-skirmish.png",
+    "iaspec": "explosivearmaments"
   },
   {
     "id": 36,
@@ -707,7 +743,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/feeding-frenzy-elite-skirmish.png"
+    "image": "deployment-cards/feeding-frenzy-elite-skirmish.png",
+    "iaspec": "elitefeedingfrenzy"
   },
   {
     "id": 37,
@@ -726,7 +763,8 @@
     "deployment_cost": 9,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/fenn-signis-skirmish.png"
+    "image": "deployment-cards/fenn-signis-skirmish.png",
+    "iaspec": "fennsignis"
   },
   {
     "id": 38,
@@ -744,7 +782,8 @@
     "deployment_cost": 2,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/first-strike-skirmish.png"
+    "image": "deployment-cards/first-strike-skirmish.png",
+    "iaspec": "firststrike"
   },
   {
     "id": 39,
@@ -762,7 +801,8 @@
     "deployment_cost": 0,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/focused-on-the-kill-skirmish.png"
+    "image": "deployment-cards/focused-on-the-kill-skirmish.png",
+    "iaspec": "focusedonthekill"
   },
   {
     "id": 40,
@@ -780,7 +820,8 @@
     "deployment_cost": 2,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/fury-of-kashyyyk-skirmish.png"
+    "image": "deployment-cards/fury-of-kashyyyk-skirmish.png",
+    "iaspec": "furyofkashyyyk"
   },
   {
     "id": 41,
@@ -800,7 +841,8 @@
     "deployment_cost": 8,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/gaarkhan-skirmish.png"
+    "image": "deployment-cards/gaarkhan-skirmish.png",
+    "iaspec": "gaarkhan"
   },
   {
     "id": 42,
@@ -820,7 +862,8 @@
     "deployment_cost": 6,
     "reinforce_cost": 3,
     "deployment_group": 2,
-    "image": "deployment-cards/gamorrean-guard.png"
+    "image": "deployment-cards/gamorrean-guard.png",
+    "iaspec": "gamorreanguard"
   },
   {
     "id": 43,
@@ -840,7 +883,8 @@
     "deployment_cost": 8,
     "reinforce_cost": 4,
     "deployment_group": 2,
-    "image": "deployment-cards/gamorrean-guard-elite.png"
+    "image": "deployment-cards/gamorrean-guard-elite.png",
+    "iaspec": "elitegamorreanguard"
   },
   {
     "id": 44,
@@ -859,7 +903,8 @@
     "deployment_cost": 8,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/general-sorin-vicious-tactician.png"
+    "image": "deployment-cards/general-sorin-vicious-tactician.png",
+    "iaspec": "generalsorin"
   },
   {
     "id": 45,
@@ -880,7 +925,8 @@
     "deployment_cost": 16,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/general-weiss-field-commander.png"
+    "image": "deployment-cards/general-weiss-field-commander.png",
+    "iaspec": "generalweiss"
   },
   {
     "id": 46,
@@ -898,7 +944,8 @@
     "deployment_cost": 3,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/gideon-argus-skirmish.png"
+    "image": "deployment-cards/gideon-argus-skirmish.png",
+    "iaspec": "gideonargus"
   },
   {
     "id": 47,
@@ -918,7 +965,8 @@
     "deployment_cost": 4,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/greedo-ambitious-mercenary.png"
+    "image": "deployment-cards/greedo-ambitious-mercenary.png",
+    "iaspec": "greedo"
   },
   {
     "id": 48,
@@ -938,7 +986,8 @@
     "deployment_cost": 8,
     "reinforce_cost": 4,
     "deployment_group": 2,
-    "image": "deployment-cards/hk-assassin-droid.png"
+    "image": "deployment-cards/hk-assassin-droid.png",
+    "iaspec": "hkassassindroid"
   },
   {
     "id": 49,
@@ -958,7 +1007,8 @@
     "deployment_cost": 11,
     "reinforce_cost": 6,
     "deployment_group": 2,
-    "image": "deployment-cards/hk-assassin-droid-elite.png"
+    "image": "deployment-cards/hk-assassin-droid-elite.png",
+    "iaspec": "elitehkassassindroid"
   },
   {
     "id": 50,
@@ -978,7 +1028,8 @@
     "deployment_cost": 12,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/han-solo-scoundrel.png"
+    "image": "deployment-cards/han-solo-scoundrel.png",
+    "iaspec": "hansolo"
   },
   {
     "id": 51,
@@ -996,7 +1047,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/headhunter-skirmish.png"
+    "image": "deployment-cards/headhunter-skirmish.png",
+    "iaspec": "headhunter"
   },
   {
     "id": 52,
@@ -1016,7 +1068,8 @@
     "deployment_cost": 6,
     "reinforce_cost": 3,
     "deployment_group": 2,
-    "image": "deployment-cards/heavy-stormtrooper.png"
+    "image": "deployment-cards/heavy-stormtrooper.png",
+    "iaspec": "heavystormtrooper"
   },
   {
     "id": 53,
@@ -1036,7 +1089,8 @@
     "deployment_cost": 8,
     "reinforce_cost": 4,
     "deployment_group": 2,
-    "image": "deployment-cards/heavy-stormtrooper-elite.png"
+    "image": "deployment-cards/heavy-stormtrooper-elite.png",
+    "iaspec": "eliteheavystormtrooper"
   },
   {
     "id": 54,
@@ -1056,7 +1110,8 @@
     "deployment_cost": 4,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/hera-syndulla-spectre-2.png"
+    "image": "deployment-cards/hera-syndulla-spectre-2.png",
+    "iaspec": "herasyndulla"
   },
   {
     "id": 55,
@@ -1074,7 +1129,8 @@
     "deployment_cost": 0,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/heroic-effort-skirmish.png"
+    "image": "deployment-cards/heroic-effort-skirmish.png",
+    "iaspec": "heroiceffort"
   },
   {
     "id": 56,
@@ -1093,7 +1149,8 @@
     "deployment_cost": 4,
     "reinforce_cost": 2,
     "deployment_group": 2,
-    "image": "deployment-cards/hired-gun.png"
+    "image": "deployment-cards/hired-gun.png",
+    "iaspec": "hiredgun"
   },
   {
     "id": 57,
@@ -1112,7 +1169,8 @@
     "deployment_cost": 6,
     "reinforce_cost": 3,
     "deployment_group": 2,
-    "image": "deployment-cards/hired-gun-elite.png"
+    "image": "deployment-cards/hired-gun-elite.png",
+    "iaspec": "elitehiredgun"
   },
   {
     "id": 58,
@@ -1132,7 +1190,8 @@
     "deployment_cost": 12,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/ig-88-assassin-droid.png"
+    "image": "deployment-cards/ig-88-assassin-droid.png",
+    "iaspec": "ig88"
   },
   {
     "id": 59,
@@ -1151,7 +1210,8 @@
     "deployment_cost": 5,
     "reinforce_cost": 3,
     "deployment_group": 2,
-    "image": "deployment-cards/isb-infiltrator.png"
+    "image": "deployment-cards/isb-infiltrator.png",
+    "iaspec": "isbinfiltrator"
   },
   {
     "id": 60,
@@ -1170,7 +1230,8 @@
     "deployment_cost": 7,
     "reinforce_cost": 4,
     "deployment_group": 2,
-    "image": "deployment-cards/isb-infiltrator-elite.png"
+    "image": "deployment-cards/isb-infiltrator-elite.png",
+    "iaspec": "eliteisbinfiltrator"
   },
   {
     "id": 61,
@@ -1189,7 +1250,8 @@
     "deployment_cost": 2,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/imperial-officer.png"
+    "image": "deployment-cards/imperial-officer.png",
+    "iaspec": "imperialofficer"
   },
   {
     "id": 62,
@@ -1208,7 +1270,8 @@
     "deployment_cost": 5,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/imperial-officer-elite.png"
+    "image": "deployment-cards/imperial-officer-elite.png",
+    "iaspec": "eliteimperialofficer"
   },
   {
     "id": 63,
@@ -1226,7 +1289,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/indentured-jester-skirmish.png"
+    "image": "deployment-cards/indentured-jester-skirmish.png",
+    "iaspec": "indenturedjester"
   },
   {
     "id": 64,
@@ -1246,7 +1310,8 @@
     "deployment_cost": 6,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/jabba-the-hutt-vile-gangster-campaign.png"
+    "image": "deployment-cards/jabba-the-hutt-vile-gangster-campaign.png",
+    "iaspec": "jabbathehuttcampaign"
   },
   {
     "id": 65,
@@ -1266,7 +1331,8 @@
     "deployment_cost": 6,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/jabba-the-hutt-vile-gangster-skirmish.png"
+    "image": "deployment-cards/jabba-the-hutt-vile-gangster-skirmish.png",
+    "iaspec": "jabbathehuttskirmish"
   },
   {
     "id": 66,
@@ -1285,7 +1351,8 @@
     "deployment_cost": 2,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/jawa-scavenger.png"
+    "image": "deployment-cards/jawa-scavenger.png",
+    "iaspec": "jawascavenger"
   },
   {
     "id": 67,
@@ -1304,7 +1371,8 @@
     "deployment_cost": 3,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/jawa-scavenger-elite-campaign.png"
+    "image": "deployment-cards/jawa-scavenger-elite-campaign.png",
+    "iaspec": "elitejawascavengercampaign"
   },
   {
     "id": 68,
@@ -1323,7 +1391,8 @@
     "deployment_cost": 3,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/jawa-scavenger-elite-skirmish.png"
+    "image": "deployment-cards/jawa-scavenger-elite-skirmish.png",
+    "iaspec": "elitejawascavengerskirmish"
   },
   {
     "id": 69,
@@ -1343,7 +1412,8 @@
     "deployment_cost": 4,
     "reinforce_cost": 2,
     "deployment_group": 2,
-    "image": "deployment-cards/jet-trooper.png"
+    "image": "deployment-cards/jet-trooper.png",
+    "iaspec": "jettrooper"
   },
   {
     "id": 70,
@@ -1363,7 +1433,8 @@
     "deployment_cost": 7,
     "reinforce_cost": 4,
     "deployment_group": 2,
-    "image": "deployment-cards/jet-trooper-elite.png"
+    "image": "deployment-cards/jet-trooper-elite.png",
+    "iaspec": "elitejettrooper"
   },
   {
     "id": 71,
@@ -1381,7 +1452,8 @@
     "deployment_cost": 5,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/jyn-odan-skirmish.png"
+    "image": "deployment-cards/jyn-odan-skirmish.png",
+    "iaspec": "jynodan"
   },
   {
     "id": 72,
@@ -1401,7 +1473,8 @@
     "deployment_cost": 10,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/kayn-somos-trooper-commander.png"
+    "image": "deployment-cards/kayn-somos-trooper-commander.png",
+    "iaspec": "kaynsomos"
   },
   {
     "id": 73,
@@ -1421,7 +1494,8 @@
     "deployment_cost": 6,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/lando-calrissian-charming-gambler.png"
+    "image": "deployment-cards/lando-calrissian-charming-gambler.png",
+    "iaspec": "landocalrissian"
   },
   {
     "id": 74,
@@ -1439,7 +1513,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/last-resort-skirmish.png"
+    "image": "deployment-cards/last-resort-skirmish.png",
+    "iaspec": "lastresort"
   },
   {
     "id": 75,
@@ -1458,7 +1533,8 @@
     "deployment_cost": 8,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/leia-organa-rebel-commander-campaign.png"
+    "image": "deployment-cards/leia-organa-rebel-commander-campaign.png",
+    "iaspec": "leiaorganacampaign"
   },
   {
     "id": 76,
@@ -1477,7 +1553,8 @@
     "deployment_cost": 8,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/leia-organa-rebel-commander-skirmish.png"
+    "image": "deployment-cards/leia-organa-rebel-commander-skirmish.png",
+    "iaspec": "leiaorganaskirmish"
   },
   {
     "id": 77,
@@ -1495,7 +1572,8 @@
     "deployment_cost": 4,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/loku-kanoloa-skirmish.png"
+    "image": "deployment-cards/loku-kanoloa-skirmish.png",
+    "iaspec": "lokukanoloa"
   },
   {
     "id": 78,
@@ -1514,7 +1592,8 @@
     "deployment_cost": 10,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/luke-skywalker-hero-of-the-rebellion.png"
+    "image": "deployment-cards/luke-skywalker-hero-of-the-rebellion.png",
+    "iaspec": "lukeskywalkerherooftherebellion"
   },
   {
     "id": 79,
@@ -1535,7 +1614,8 @@
     "deployment_cost": 12,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/luke-skywalker-jedi-knight.png"
+    "image": "deployment-cards/luke-skywalker-jedi-knight.png",
+    "iaspec": "lukeskywalkerjediknight"
   },
   {
     "id": 80,
@@ -1553,7 +1633,8 @@
     "deployment_cost": 5,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/mhd-19-skirmish.png"
+    "image": "deployment-cards/mhd-19-skirmish.png",
+    "iaspec": "mhd19"
   },
   {
     "id": 81,
@@ -1571,7 +1652,8 @@
     "deployment_cost": 3,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/mak-eshkarey-skirmish.png"
+    "image": "deployment-cards/mak-eshkarey-skirmish.png",
+    "iaspec": "makeshkarey"
   },
   {
     "id": 82,
@@ -1589,7 +1671,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/motivation-skirmish.png"
+    "image": "deployment-cards/motivation-skirmish.png",
+    "iaspec": "motivation"
   },
   {
     "id": 83,
@@ -1608,7 +1691,8 @@
     "deployment_cost": 4,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/murne-rin-skirmish.png"
+    "image": "deployment-cards/murne-rin-skirmish.png",
+    "iaspec": "murnerin"
   },
   {
     "id": 84,
@@ -1628,7 +1712,8 @@
     "deployment_cost": 4,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/nexu.png"
+    "image": "deployment-cards/nexu.png",
+    "iaspec": "nexu"
   },
   {
     "id": 85,
@@ -1648,7 +1733,8 @@
     "deployment_cost": 6,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/nexu-elite.png"
+    "image": "deployment-cards/nexu-elite.png",
+    "iaspec": "elitenexu"
   },
   {
     "id": 86,
@@ -1666,7 +1752,8 @@
     "deployment_cost": 7,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/obi-wan-kenobi-jedi-knight-skirmish.png"
+    "image": "deployment-cards/obi-wan-kenobi-jedi-knight-skirmish.png",
+    "iaspec": "obiwankenobiskirmish"
   },
   {
     "id": 87,
@@ -1684,7 +1771,8 @@
     "deployment_cost": 10,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/obi-wan-kenobi-jedi-knight-campaign.png"
+    "image": "deployment-cards/obi-wan-kenobi-jedi-knight-campaign.png",
+    "iaspec": "obiwankenobicampaign"
   },
   {
     "id": 88,
@@ -1702,7 +1790,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/on-a-diplomatic-mission-skirmish.png"
+    "image": "deployment-cards/on-a-diplomatic-mission-skirmish.png",
+    "iaspec": "onadiplomaticmission"
   },
   {
     "id": 89,
@@ -1721,7 +1810,8 @@
     "deployment_cost": 6,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/onar-koma-skirmish.png"
+    "image": "deployment-cards/onar-koma-skirmish.png",
+    "iaspec": "onarkoma"
   },
   {
     "id": 90,
@@ -1739,7 +1829,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/prey-on-the-weak-skirmish.png"
+    "image": "deployment-cards/prey-on-the-weak-skirmish.png",
+    "iaspec": "preyontheweak"
   },
   {
     "id": 91,
@@ -1758,7 +1849,8 @@
     "deployment_cost": 3,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/probe-droid.png"
+    "image": "deployment-cards/probe-droid.png",
+    "iaspec": "probedroid"
   },
   {
     "id": 92,
@@ -1777,7 +1869,8 @@
     "deployment_cost": 5,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/probe-droid-elite.png"
+    "image": "deployment-cards/probe-droid-elite.png",
+    "iaspec": "eliteprobedroid"
   },
   {
     "id": 93,
@@ -1795,7 +1888,8 @@
     "deployment_cost": 2,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/punishing-strike-skirmish.png"
+    "image": "deployment-cards/punishing-strike-skirmish.png",
+    "iaspec": "punishingstrike"
   },
   {
     "id": 94,
@@ -1813,7 +1907,8 @@
     "deployment_cost": 3,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/r2-d2-loyal-astromech-campaign.png"
+    "image": "deployment-cards/r2-d2-loyal-astromech-campaign.png",
+    "iaspec": "r2d2campaign"
   },
   {
     "id": 95,
@@ -1831,7 +1926,8 @@
     "deployment_cost": 3,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/r2-d2-loyal-astromech-skirmish.png"
+    "image": "deployment-cards/r2-d2-loyal-astromech-skirmish.png",
+    "iaspec": "r2d2skirmish"
   },
   {
     "id": 96,
@@ -1850,7 +1946,8 @@
     "deployment_cost": 10,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/rancor-elite-campaign.png"
+    "image": "deployment-cards/rancor-elite-campaign.png",
+    "iaspec": "eliterancorcampaign"
   },
   {
     "id": 97,
@@ -1869,7 +1966,8 @@
     "deployment_cost": 10,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/rancor-elite-skirmish.png"
+    "image": "deployment-cards/rancor-elite-skirmish.png",
+    "iaspec": "eliterancorskirmish"
   },
   {
     "id": 98,
@@ -1887,7 +1985,8 @@
     "deployment_cost": 2,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/rebel-high-command-skirmish.png"
+    "image": "deployment-cards/rebel-high-command-skirmish.png",
+    "iaspec": "rebelhighcommand"
   },
   {
     "id": 99,
@@ -1907,7 +2006,8 @@
     "deployment_cost": 5,
     "reinforce_cost": 3,
     "deployment_group": 2,
-    "image": "deployment-cards/rebel-saboteur.png"
+    "image": "deployment-cards/rebel-saboteur.png",
+    "iaspec": "rebelsaboteur"
   },
   {
     "id": 100,
@@ -1927,7 +2027,8 @@
     "deployment_cost": 7,
     "reinforce_cost": 4,
     "deployment_group": 2,
-    "image": "deployment-cards/rebel-saboteur-elite.png"
+    "image": "deployment-cards/rebel-saboteur-elite.png",
+    "iaspec": "eliterebelsaboteur"
   },
   {
     "id": 101,
@@ -1946,7 +2047,8 @@
     "deployment_cost": 6,
     "reinforce_cost": 2,
     "deployment_group": 3,
-    "image": "deployment-cards/rebel-trooper.png"
+    "image": "deployment-cards/rebel-trooper.png",
+    "iaspec": "rebeltrooper"
   },
   {
     "id": 102,
@@ -1965,7 +2067,8 @@
     "deployment_cost": 9,
     "reinforce_cost": 3,
     "deployment_group": 3,
-    "image": "deployment-cards/rebel-trooper-elite.png"
+    "image": "deployment-cards/rebel-trooper-elite.png",
+    "iaspec": "eliterebeltrooper"
   },
   {
     "id": 103,
@@ -1985,7 +2088,8 @@
     "deployment_cost": 8,
     "reinforce_cost": 4,
     "deployment_group": 2,
-    "image": "deployment-cards/royal-guard.png"
+    "image": "deployment-cards/royal-guard.png",
+    "iaspec": "royalguard"
   },
   {
     "id": 104,
@@ -2005,7 +2109,8 @@
     "deployment_cost": 12,
     "reinforce_cost": 6,
     "deployment_group": 2,
-    "image": "deployment-cards/royal-guard-elite.png"
+    "image": "deployment-cards/royal-guard-elite.png",
+    "iaspec": "eliteroyalguard"
   },
   {
     "id": 105,
@@ -2025,7 +2130,8 @@
     "deployment_cost": 15,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/royal-guard-champion.png"
+    "image": "deployment-cards/royal-guard-champion.png",
+    "iaspec": "royalguardchampion"
   },
   {
     "id": 106,
@@ -2043,7 +2149,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/rule-by-fear-skirmish.png"
+    "image": "deployment-cards/rule-by-fear-skirmish.png",
+    "iaspec": "rulebyfear"
   },
   {
     "id": 107,
@@ -2062,7 +2169,8 @@
     "deployment_cost": 10,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/sc2-m-repulsor-tank-elite.png"
+    "image": "deployment-cards/sc2-m-repulsor-tank-elite.png",
+    "iaspec": "elitesc2mrepulsortank"
   },
   {
     "id": 108,
@@ -2081,7 +2189,8 @@
     "deployment_cost": 6,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/saska-teft-skirmish.png"
+    "image": "deployment-cards/saska-teft-skirmish.png",
+    "iaspec": "saskateft"
   },
   {
     "id": 109,
@@ -2099,7 +2208,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/scavenged-weaponry-skirmish.png"
+    "image": "deployment-cards/scavenged-weaponry-skirmish.png",
+    "iaspec": "scavengedweaponry"
   },
   {
     "id": 110,
@@ -2118,7 +2228,8 @@
     "deployment_cost": 8,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/shyla-varad-skirmish.png"
+    "image": "deployment-cards/shyla-varad-skirmish.png",
+    "iaspec": "shylavarad"
   },
   {
     "id": 111,
@@ -2136,7 +2247,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/smugglers-run-skirmish.png"
+    "image": "deployment-cards/smugglers-run-skirmish.png",
+    "iaspec": "smugglersrun"
   },
   {
     "id": 112,
@@ -2155,7 +2267,8 @@
     "deployment_cost": 7,
     "reinforce_cost": 2,
     "deployment_group": 3,
-    "image": "deployment-cards/snowtrooper.png"
+    "image": "deployment-cards/snowtrooper.png",
+    "iaspec": "snowtrooper"
   },
   {
     "id": 113,
@@ -2174,7 +2287,8 @@
     "deployment_cost": 10,
     "reinforce_cost": 3,
     "deployment_group": 3,
-    "image": "deployment-cards/snowtrooper-elite.png"
+    "image": "deployment-cards/snowtrooper-elite.png",
+    "iaspec": "elitesnowtrooper"
   },
   {
     "id": 114,
@@ -2193,7 +2307,8 @@
     "deployment_cost": 6,
     "reinforce_cost": 2,
     "deployment_group": 3,
-    "image": "deployment-cards/stormtrooper.png"
+    "image": "deployment-cards/stormtrooper.png",
+    "iaspec": "stormtrooper"
   },
   {
     "id": 115,
@@ -2212,7 +2327,8 @@
     "deployment_cost": 9,
     "reinforce_cost": 3,
     "deployment_group": 3,
-    "image": "deployment-cards/stormtrooper-elite.png"
+    "image": "deployment-cards/stormtrooper-elite.png",
+    "iaspec": "elitestormtrooper"
   },
   {
     "id": 116,
@@ -2230,7 +2346,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/survivalist-skirmish.png"
+    "image": "deployment-cards/survivalist-skirmish.png",
+    "iaspec": "survivalist"
   },
   {
     "id": 117,
@@ -2248,7 +2365,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/targeting-computer-skirmish.png"
+    "image": "deployment-cards/targeting-computer-skirmish.png",
+    "iaspec": "targetingcomputer"
   },
   {
     "id": 118,
@@ -2266,7 +2384,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/temporary-alliance-a-common-enemy-skirmish.png"
+    "image": "deployment-cards/temporary-alliance-a-common-enemy-skirmish.png",
+    "iaspec": "temporaryalliancemercenary"
   },
   {
     "id": 119,
@@ -2284,7 +2403,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/temporary-alliance-hired-guns-skirmish.png"
+    "image": "deployment-cards/temporary-alliance-hired-guns-skirmish.png",
+    "iaspec": "temporaryallianceimperial"
   },
   {
     "id": 120,
@@ -2302,7 +2422,8 @@
     "deployment_cost": 2,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/the-generals-ranks-skirmish.png"
+    "image": "deployment-cards/the-generals-ranks-skirmish.png",
+    "iaspec": "thegeneralsranks"
   },
   {
     "id": 121,
@@ -2322,7 +2443,8 @@
     "deployment_cost": 9,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/the-grand-inquisitor-sith-loyalist.png"
+    "image": "deployment-cards/the-grand-inquisitor-sith-loyalist.png",
+    "iaspec": "thegrandinquisitor"
   },
   {
     "id": 122,
@@ -2342,7 +2464,8 @@
     "deployment_cost": 7,
     "reinforce_cost": 3,
     "deployment_group": 2,
-    "image": "deployment-cards/trandoshan-hunter.png"
+    "image": "deployment-cards/trandoshan-hunter.png",
+    "iaspec": "trandoshanhunter"
   },
   {
     "id": 123,
@@ -2362,7 +2485,8 @@
     "deployment_cost": 10,
     "reinforce_cost": 5,
     "deployment_group": 2,
-    "image": "deployment-cards/trandoshan-hunter-elite.png"
+    "image": "deployment-cards/trandoshan-hunter-elite.png",
+    "iaspec": "elitetrandoshanhunter"
   },
   {
     "id": 124,
@@ -2380,7 +2504,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/trusted-ally-skirmish.png"
+    "image": "deployment-cards/trusted-ally-skirmish.png",
+    "iaspec": "trustedally"
   },
   {
     "id": 125,
@@ -2399,7 +2524,8 @@
     "deployment_cost": 5,
     "reinforce_cost": 2,
     "deployment_group": 2,
-    "image": "deployment-cards/tusken-raider.png"
+    "image": "deployment-cards/tusken-raider.png",
+    "iaspec": "tuskenraider"
   },
   {
     "id": 126,
@@ -2418,7 +2544,8 @@
     "deployment_cost": 7,
     "reinforce_cost": 3,
     "deployment_group": 2,
-    "image": "deployment-cards/tusken-raider-elite.png"
+    "image": "deployment-cards/tusken-raider-elite.png",
+    "iaspec": "elitetuskenraider"
   },
   {
     "id": 127,
@@ -2437,7 +2564,8 @@
     "deployment_cost": 3,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/ugnaught-tinkerer.png"
+    "image": "deployment-cards/ugnaught-tinkerer.png",
+    "iaspec": "ugnaughttinkerer"
   },
   {
     "id": 128,
@@ -2456,7 +2584,8 @@
     "deployment_cost": 5,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/ugnaught-tinkerer-elite.png"
+    "image": "deployment-cards/ugnaught-tinkerer-elite.png",
+    "iaspec": "eliteugnaughttinkerer"
   },
   {
     "id": 129,
@@ -2474,7 +2603,8 @@
     "deployment_cost": 2,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/under-duress-skirmish.png"
+    "image": "deployment-cards/under-duress-skirmish.png",
+    "iaspec": "underduress"
   },
   {
     "id": 130,
@@ -2492,7 +2622,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/unshakable-skirmish.png"
+    "image": "deployment-cards/unshakable-skirmish.png",
+    "iaspec": "unshakable"
   },
   {
     "id": 131,
@@ -2510,7 +2641,8 @@
     "deployment_cost": 2,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/vaders-finest-skirmish.png"
+    "image": "deployment-cards/vaders-finest-skirmish.png",
+    "iaspec": "vadersfinest"
   },
   {
     "id": 132,
@@ -2529,7 +2661,8 @@
     "deployment_cost": 8,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/verena-talos-skirmish.png"
+    "image": "deployment-cards/verena-talos-skirmish.png",
+    "iaspec": "verenatalos"
   },
   {
     "id": 133,
@@ -2548,7 +2681,8 @@
     "deployment_cost": 5,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/vinto-hreeda-skirmish.png"
+    "image": "deployment-cards/vinto-hreeda-skirmish.png",
+    "iaspec": "vintohreeda"
   },
   {
     "id": 134,
@@ -2568,7 +2702,8 @@
     "deployment_cost": 5,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/wampa.png"
+    "image": "deployment-cards/wampa.png",
+    "iaspec": "wampa"
   },
   {
     "id": 135,
@@ -2588,7 +2723,8 @@
     "deployment_cost": 8,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/wampa-elite.png"
+    "image": "deployment-cards/wampa-elite.png",
+    "iaspec": "elitewampa"
   },
   {
     "id": 136,
@@ -2608,7 +2744,8 @@
     "deployment_cost": 5,
     "reinforce_cost": 3,
     "deployment_group": 2,
-    "image": "deployment-cards/weequay-pirate.png"
+    "image": "deployment-cards/weequay-pirate.png",
+    "iaspec": "weequaypirate"
   },
   {
     "id": 137,
@@ -2628,7 +2765,8 @@
     "deployment_cost": 7,
     "reinforce_cost": 4,
     "deployment_group": 2,
-    "image": "deployment-cards/weequay-pirate-elite.png"
+    "image": "deployment-cards/weequay-pirate-elite.png",
+    "iaspec": "eliteweequaypirate"
   },
   {
     "id": 138,
@@ -2648,7 +2786,8 @@
     "deployment_cost": 6,
     "reinforce_cost": 2,
     "deployment_group": 3,
-    "image": "deployment-cards/wing-guard.png"
+    "image": "deployment-cards/wing-guard.png",
+    "iaspec": "wingguard"
   },
   {
     "id": 139,
@@ -2668,7 +2807,8 @@
     "deployment_cost": 9,
     "reinforce_cost": 3,
     "deployment_group": 3,
-    "image": "deployment-cards/wing-guard-elite.png"
+    "image": "deployment-cards/wing-guard-elite.png",
+    "iaspec": "elitewingguard"
   },
   {
     "id": 140,
@@ -2688,7 +2828,8 @@
     "deployment_cost": 8,
     "reinforce_cost": 4,
     "deployment_group": 2,
-    "image": "deployment-cards/wookiee-warrior.png"
+    "image": "deployment-cards/wookiee-warrior.png",
+    "iaspec": "wookieewarrior"
   },
   {
     "id": 141,
@@ -2708,7 +2849,8 @@
     "deployment_cost": 11,
     "reinforce_cost": 6,
     "deployment_group": 2,
-    "image": "deployment-cards/wookiee-warrior-elite.png"
+    "image": "deployment-cards/wookiee-warrior-elite.png",
+    "iaspec": "elitewookieewarrior"
   },
   {
     "id": 142,
@@ -2726,7 +2868,8 @@
     "deployment_cost": 1,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/zillo-technique-skirmish.png"
+    "image": "deployment-cards/zillo-technique-skirmish.png",
+    "iaspec": "zillotechnique"
   },
   {
     "id": 143,
@@ -2746,7 +2889,8 @@
     "deployment_cost": 9,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/at-dp-elite.png"
+    "image": "deployment-cards/at-dp-elite.png",
+    "iaspec": "eliteatdp"
   },
   {
     "id": 144,
@@ -2767,7 +2911,8 @@
     "deployment_cost": 8,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/ahsoka-tano-rebel-instigator.png"
+    "image": "deployment-cards/ahsoka-tano-rebel-instigator.png",
+    "iaspec": "ahsokatano"
   },
   {
     "id": 145,
@@ -2787,7 +2932,8 @@
     "deployment_cost": 4,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/clawdite-shapeshifter.png"
+    "image": "deployment-cards/clawdite-shapeshifter.png",
+    "iaspec": "clawditeshapeshifter"
   },
   {
     "id": 146,
@@ -2807,7 +2953,8 @@
     "deployment_cost": 6,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/clawdite-shapeshifter-elite.png"
+    "image": "deployment-cards/clawdite-shapeshifter-elite.png",
+    "iaspec": "eliteclawditeshapeshifter"
   },
   {
     "id": 147,
@@ -2825,7 +2972,8 @@
     "deployment_cost": -5,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/driven-by-hatred-skirmish.png"
+    "image": "deployment-cards/driven-by-hatred-skirmish.png",
+    "iaspec": "drivenbyhatred"
   },
   {
     "id": 148,
@@ -2844,7 +2992,8 @@
     "deployment_cost": 9,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/drokkatta-skirmish.png"
+    "image": "deployment-cards/drokkatta-skirmish.png",
+    "iaspec": "drokkatta"
   },
   {
     "id": 149,
@@ -2864,7 +3013,8 @@
     "deployment_cost": 8,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/emperor-palpatine-sith-master.png"
+    "image": "deployment-cards/emperor-palpatine-sith-master.png",
+    "iaspec": "emperorpalpatine"
   },
   {
     "id": 150,
@@ -2884,7 +3034,8 @@
     "deployment_cost": 5,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/jarrod-kelvin-skirmish.png"
+    "image": "deployment-cards/jarrod-kelvin-skirmish.png",
+    "iaspec": "jarrodkelvin"
   },
   {
     "id": 151,
@@ -2903,7 +3054,8 @@
     "deployment_cost": 7,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/ko-tun-feralo-skirmish.png"
+    "image": "deployment-cards/ko-tun-feralo-skirmish.png",
+    "iaspec": "kotunferalo"
   },
   {
     "id": 152,
@@ -2923,7 +3075,8 @@
     "deployment_cost": 7,
     "reinforce_cost": null,
     "deployment_group": 1,
-    "image": "deployment-cards/maul-seeker-of-vengeance.png"
+    "image": "deployment-cards/maul-seeker-of-vengeance.png",
+    "iaspec": "maul"
   },
   {
     "id": 153,
@@ -2943,7 +3096,8 @@
     "deployment_cost": 5,
     "reinforce_cost": 2,
     "deployment_group": 2,
-    "image": "deployment-cards/riot-trooper-campaign.png"
+    "image": "deployment-cards/riot-trooper-campaign.png",
+    "iaspec": "riottroopercampaign"
   },
   {
     "id": 154,
@@ -2963,7 +3117,8 @@
     "deployment_cost": 5,
     "reinforce_cost": 2,
     "deployment_group": 2,
-    "image": "deployment-cards/riot-trooper-skirmish.png"
+    "image": "deployment-cards/riot-trooper-skirmish.png",
+    "iaspec": "riottrooperskirmish"
   },
   {
     "id": 155,
@@ -2983,7 +3138,8 @@
     "deployment_cost": 7,
     "reinforce_cost": 3,
     "deployment_group": 2,
-    "image": "deployment-cards/riot-trooper-elite-campaign.png"
+    "image": "deployment-cards/riot-trooper-elite-campaign.png",
+    "iaspec": "eliteriottroopercampaign"
   },
   {
     "id": 156,
@@ -3003,7 +3159,8 @@
     "deployment_cost": 7,
     "reinforce_cost": 3,
     "deployment_group": 2,
-    "image": "deployment-cards/riot-trooper-elite-skirmish.png"
+    "image": "deployment-cards/riot-trooper-elite-skirmish.png",
+    "iaspec": "eliteriottrooperskirmish"
   },
   {
     "id": 157,
@@ -3021,7 +3178,8 @@
     "deployment_cost": -2,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/rogue-smuggler-skirmish.png"
+    "image": "deployment-cards/rogue-smuggler-skirmish.png",
+    "iaspec": "roguesmuggler"
   },
   {
     "id": 158,
@@ -3042,7 +3200,8 @@
     "deployment_cost": 6,
     "reinforce_cost": 3,
     "deployment_group": 2,
-    "image": "deployment-cards/sentry-droid.png"
+    "image": "deployment-cards/sentry-droid.png",
+    "iaspec": "sentrydroid"
   },
   {
     "id": 159,
@@ -3063,7 +3222,8 @@
     "deployment_cost": 10,
     "reinforce_cost": 5,
     "deployment_group": 2,
-    "image": "deployment-cards/sentry-droid-elite.png"
+    "image": "deployment-cards/sentry-droid-elite.png",
+    "iaspec": "elitesentrydroid"
   },
   {
     "id": 160,
@@ -3081,6 +3241,7 @@
     "deployment_cost": -4,
     "reinforce_cost": null,
     "deployment_group": null,
-    "image": "deployment-cards/wookiee-avenger-skirmish.png"
+    "image": "deployment-cards/wookiee-avenger-skirmish.png",
+    "iaspec": "wookieeavenger"
   }
 ]

--- a/schemas/command-cards.json
+++ b/schemas/command-cards.json
@@ -15,6 +15,11 @@
       "description": "Command card name",
       "minLength": 1
     },
+    "iaspec": {
+      "type": "string",
+      "description": "iaspec code",
+      "minLength": 1
+    },
     "cost": {
       "description": "The cost associated with using this command card.",
       "type": "integer",
@@ -33,6 +38,7 @@
   },
   "required": [
     "id",
+    "iaspec",
     "name",
     "cost",
     "limit",

--- a/schemas/companion-cards.json
+++ b/schemas/companion-cards.json
@@ -15,6 +15,11 @@
       "description": "Companion card name",
       "minLength": 1
     },
+    "iaspec": {
+      "type": "string",
+      "description": "iaspec code",
+      "minLength": 1
+    },
     "image": {
       "description": "The file path for this companion card's image.",
       "$ref": "definitions.json#/definitions/image-file-path"
@@ -32,6 +37,7 @@
   },
   "required": [
     "id",
+    "iaspec",
     "name",
     "image",
     "traits"

--- a/schemas/deployment-cards.json
+++ b/schemas/deployment-cards.json
@@ -15,6 +15,11 @@
       "description": "Deployment card name",
       "minLength": 1
     },
+    "iaspec": {
+      "type": "string",
+      "description": "iaspec code",
+      "minLength": 1
+    },
     "description": {
       "description": "Deployment card description",
       "oneOf": [
@@ -99,6 +104,7 @@
   },
   "required": [
     "id",
+    "iaspec",
     "name",
     "image",
     "traits",

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,10 +1,11 @@
 from os import path
 from itertools import product, chain
+from collections import Counter
 
 import pytest
 
 from tests.constants import CONTENT_TYPES, DEPLOYMENT_TRAITS, GAME_MODES, BUFF_TYPES
-from tests.utils import get_data
+from tests.utils import get_data, flatten_list, get_data_for
 
 
 class TestIntegrity:
@@ -131,3 +132,22 @@ class TestRewardIntegrity:
     ])
     def test_unique_deployment_does_not_have_a_reinforce_cost(self, entry):
         assert entry['traits'] is None
+
+
+class TestCanonicalNames:
+    def test_no_duplicate_iaspec_names(self):
+        canonical_names = [
+            m['iaspec']
+            for m in flatten_list(
+                get_data_for(
+                    CONTENT_TYPES.DEPLOYMENT, CONTENT_TYPES.COMMAND, CONTENT_TYPES.COMPANION
+                ).values()
+            )
+        ]
+
+        Counter(canonical_names)
+
+        duplicates = [item for item, count in Counter(canonical_names).items() if count > 1]
+
+        if duplicates:
+            pytest.fail(f"The following canonical names are duplicated: {', '.join(duplicates)}")


### PR DESCRIPTION
## Proposed iaspec change

### Definition

- Canonical names are unique across the whole dataset. (we could do away with this if it is problematic down the like, but for the moment it is easily achieved)
- Canonical names only use alphanumerical characters in lower case (no spaces allowed)

- To get a canonical name for a particular component, there are 4 strategies:
    1. Use **elite** and **name** values
    1. Use **elite**, **name** and **game mode** values.
    1. Use **elite**, **name** and **affiliation** values.
    1. Use **elite**, **name** and **description** values.

- If an entry does not have a given value, or that values is `null` or `false`, don't add anything to the canonical name.
- If an entry's value is set to `true`, then add that value's name to the canonical name, except in the case of *elite* (see below)
- If an user has ``entry.elite == true``, only add `'elite'` to the canonical name if  ``entry.unique == false``
- If a entry's value references an array of other elements, only add to the name if that array has only 1 element. Example: (Only add `'skirmish'` or `'campaign'` to the canonical name if `entry.modes.length == 1`)


### Procedure

1. You take all entries that are going to need canonical names (regardless of type) and you define canonical names as an empty string. (just to begin with, we will change)
1. Run the strategies in ascending order and do the following:
    1. You take all the entries that share the same canonical name and use the current strategy to get new canonical names
    1. All the entries that do not have duplicates are taken out of this loop and no longer tampered with.
    1. Go back to step 2.ii using the next strategy.
1. If we continue to have duplicated canonical names, then this specification needs to further adapt to accommodate for the additional edge cases 

I have abstracted this in some code, but it is not the easiest to read at the moment.

### Results
Using the above I'm able to match 93.53% of the canonical names currently in [iaskirmish-data](https://github.com/kingargyle/iaskirmish-data) (340 unique names)

This are the mismatches:

iaspec | proposed | notes
------ | -------- | -----
lukeskywalkerjedi | lukeskywalkerjediknight | Needs renaming to use the description/tag line
lukeskywalker | lukeskywalkerherooftherebellion, lukeskywalkerjediknight | Needs desambiguation
leiaorgana | leiaorganacampaign, leiaorganaskirmish | Needs desambiguation
obiwankenobi | obiwankenobiskirmish, obiwankenobicampaign | Needs desambiguation
r2d2 | r2d2campaign, r2d2skirmish | Needs desambiguation
furyofkashyyk | furyofkashyyyk | There is a typo in iaskirmish-data
atst | eliteatst | Needs to accomodate for the fact that there could be a regular variant
sc2mrepulsortank | elitesc2mrepulsortank | Needs to accomodate for the fact that there could be a regular variant
atdp | eliteatdp | Needs to accomodate for the fact that there could be a regular variant
agentblaise | agentblaisecampaign, agentblaiseskirmish | Needs desambiguation
dewbackrider | elitedewbackrider | Needs to accomodate for the fact that there could be a regular variant
riottrooper | riottroopercampaign, riottrooperskirmish, eliteriottroopercampaign, eliteriottrooperskirmish | Needs desambiguation
crosstraining | elitecrosstraining | Needs to accomodate for the fact that there could be a regular variant
temporaryallianceempire | temporaryalliancemercenary, temporaryallianceimperial | Needs renaming (Imperial deployment, Mercenary deployment, Rebel deployment)
rancor | eliterancorcampaign, eliterancorskirmish | Needs to accomodate for the fact that there could be a regular variant
bantharider | elitebantharider | Needs to accomodate for the fact that there could be a regular variant
bossk | bosskmercenary, bosskrebel | Needs desambiguation
jabbathehutt | jabbathehuttcampaign, jabbathehuttskirmish | Needs desambiguation
elitejawascavenger | jawascavenger, elitejawascavengercampaign, elitejawascavengerskirmish | Needs to accommodate for 3 versions
tempoaryalliancescum | None | There is a typo in iaskirmish-data
feedingfrenzy | elitefeedingfrenzy |  Needs to accomodate for the fact that there could be a regular variant
sarlacsweep | sarlaccsweep | There is a typo in iaskirmish-data